### PR TITLE
Fixes 0.13 support via using the 0.13 required_providers syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| datadog | >= 2.12 |
+| datadog | >= 2.13 |
 | local | >= 1.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| datadog | >= 2.12 |
+| datadog | >= 2.13 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,16 +3,16 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| datadog | >= 2.12 |
+| datadog | >= 2.13 |
 | local | >= 1.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| datadog | >= 2.12 |
+| datadog | >= 2.13 |
 
 ## Inputs
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,9 +1,18 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws     = ">= 2.0"
-    local   = ">= 1.3"
-    datadog = ">= 2.12"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    datadog = {
+      source  = "datadog/datadog"
+      version = ">= 2.13"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,18 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws     = ">= 2.0"
-    local   = ">= 1.3"
-    datadog = ">= 2.12"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    datadog = {
+      source  = "datadog/datadog"
+      version = ">= 2.13"
+    }
   }
 }


### PR DESCRIPTION
## what
* Fixes 0.13 support
* Pins Terraform >= 0.12.26 

## why
* The minimum terraform was increased due to the [required_providers syntax backwards compatibility](https://www.terraform.io/docs/configuration/provider-requirements.html#v0-12-compatible-provider-requirements). 
* When running this module on 0.13, a terraform init results in the below error regardless of the fact that the correct required_providers syntax being used in the root module. I *believe* this is due to there never being a hashicorp/datadog provider during 0.12 as the datadog provider was [just recently published](https://github.com/DataDog/terraform-provider-datadog/issues/637#issuecomment-693457944) as a community provider. I think this causes Terraform 0.13 to try to lookup the datadog provider as if it was previously published via hashicorp/, which blows up like below. 

```
Error: Failed to install providers

Could not find required providers, but found possible alternatives:

  hashicorp/datadog -> datadog/datadog

If these suggestions look correct, upgrade your configuration with the
following command:

The following remote modules must also be upgraded for Terraform 0.13
compatibility:
- module.datadog_integration at
git::https://github.com/cloudposse/terraform-aws-datadog-integration.git?ref=tags/0.5.0
```

## references
* See discussion in Slack: https://sweetops.slack.com/archives/CCT1E7JJY/p1603214212249300
* See the same fix / changes in [terraform-aws-datadog-integration#15](https://github.com/cloudposse/terraform-aws-datadog-integration/pull/15). 

