### PR TITLE
Update Datadog monitors

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,7 +1,7 @@
 name: chatops
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 jobs:
   default:
@@ -33,3 +33,5 @@ jobs:
           permission: triage
           issue-type: pull-request
           reactions: false
+
+

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Introduction
 
-Datadog monitors are configured in a YAML configuration file.
+Datadog monitors are configured in YAML configuration files.
 
-See [monitors.yaml](examples/complete/monitors.yaml) for monitor configuration examples.
+See [monitors](examples/complete/monitors) for monitor configuration examples.
 
 For more details, refer to:
 
@@ -77,6 +77,9 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
 
 
 For a complete example, see [examples/complete](examples/complete).
+
+For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest)
+(which tests and deploys the example on Datadog), see [test](test).
 
 ```hcl
   locals {

--- a/README.yaml
+++ b/README.yaml
@@ -47,9 +47,9 @@ description: |-
   Terraform module to configure [Datadog monitors](https://docs.datadoghq.com/api/v1/monitors/).
 
 introduction: |-
-  Datadog monitors are configured in a YAML configuration file.
+  Datadog monitors are configured in YAML configuration files.
 
-  See [monitors.yaml](examples/complete/monitors.yaml) for monitor configuration examples.
+  See [monitors](examples/complete/monitors) for monitor configuration examples.
 
   For more details, refer to:
 
@@ -60,6 +60,9 @@ introduction: |-
 # How to use this project
 usage: |-
   For a complete example, see [examples/complete](examples/complete).
+
+  For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest)
+  (which tests and deploys the example on Datadog), see [test](test).
 
   ```hcl
     locals {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,9 @@
 locals {
-  datadog_monitors = yamldecode(file("monitors.yaml"))
+  datadog_monitors = merge([
+    for monitors_file in fileset(path.module, "monitors/*.yaml") : {
+      for k, v in yamldecode(file(format("%s/%s", path.module, monitors_file))) : k => v
+    }
+  ]...)
 }
 
 module "datadog_monitors" {

--- a/examples/complete/monitors/aurora.yaml
+++ b/examples/complete/monitors/aurora.yaml
@@ -1,0 +1,37 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+aurora-replica-lag:
+  name: "(RDS) Aurora Replica Lag Detected"
+  type: metric alert
+  query: |
+    min(last_15m):min:aws.rds.aurora_replica_lag{*} by {dbinstanceidentifier} > 1000
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) Replica lag has been greater than half a second for more than 15 minutes
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) Replica lag has been greater than 1s for more than 15 minutes
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 1000
+    warning: 500
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:

--- a/examples/complete/monitors/ec2.yaml
+++ b/examples/complete/monitors/ec2.yaml
@@ -1,0 +1,32 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+ec2-failed-status-check:
+  name: "(EC2) Failed Status Check"
+  type: metric alert
+  query: |
+    avg(last_10m):avg:aws.ec2.status_check_failed{*} by {instance_id} > 0
+  message: |
+    ({stage} {region}) {instance_id} failed a status check
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 0
+    #warning:
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:

--- a/examples/complete/monitors/k8s.yaml
+++ b/examples/complete/monitors/k8s.yaml
@@ -5,14 +5,14 @@ k8s-replica-pod-down:
   name: "(k8s) Replica Pod is down"
   type: query alert
   query: |
-    avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{*} by {deployment} - avg:kubernetes_state.deployment.replicas_ready{*} by {deployment} >= 2
+    avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{*} by {cluster_name,deployment} - avg:kubernetes_state.deployment.replicas_ready{*} by {cluster_name,deployment} >= 2
   message: |
-    ({{event.tags.cluster_name}} {{deployment}}) More than one Deployments Replica's pods are down
+    ({{cluster_name.name}}) More than one Deployments Replica's pods are down on {{deployment.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
-  notify_no_data: true
+  notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -30,14 +30,14 @@ k8s-pod-restarting:
   name: "(k8s) Pods are restarting multiple times"
   type: query alert
   query: |
-    change(sum(last_5m),last_5m):exclude_null(avg:kubernetes.containers.restarts{*} by {pod_name}) > 5
+    change(sum(last_5m),last_5m):exclude_null(avg:kubernetes.containers.restarts{*} by {cluster_name,kube_namespace,pod_name}) > 5
   message: |
-    ({{event.tags.cluster_name}}) pod {{pod_name.name}} is restarting multiple times on {{kube_namespace.name}}
+    ({{cluster_name.name}}) pod {{pod_name.name}} is restarting multiple times on {{kube_namespace.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
-  notify_no_data: true
+  notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -56,9 +56,9 @@ k8s-statefulset-down:
   name: "(k8s) StatefulSet Replica Pod is down"
   type: query alert
   query: |
-    max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {statefulset} - sum:kubernetes_state.statefulset.replicas_ready{*} by {statefulset} >= 2
+    max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {cluster_name,statefulset} - sum:kubernetes_state.statefulset.replicas_ready{*} by {cluster_name,statefulset} >= 2
   message: |
-    ({{event.tags.cluster_name}} {{statefulset}}) More than one StatefulSet Replica's pods are down
+    ({{cluster_name.name}} {{statefulset.name}}) More than one StatefulSet Replica's pods are down
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
@@ -82,9 +82,9 @@ k8s-crashloopBackOff:
   name: "(k8s) CrashloopBackOff detected"
   type: query alert
   query: |
-    max(last_10m):max:kubernetes_state.container.waiting{reason:crashloopbackoff} by {kube_namespace,pod_name} >= 1
+    max(last_10m):max:kubernetes_state.container.waiting{reason:crashloopbackoff} by {cluster_name,kube_namespace,pod_name} >= 1
   message: |
-    ({{event.tags.cluster_name}}) pod {{pod_name.name}} is CrashloopBackOff on {{kube_namespace.name}}
+    ({{cluster_name.name}}) pod {{pod_name.name}} is CrashloopBackOff on {{kube_namespace.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
@@ -107,14 +107,14 @@ k8s-multiple-pods-failing:
   name: "(k8s) Multiple Pods are failing"
   type: query alert
   query: |
-    change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{phase:failed} by {kubernetes_cluster,kube_namespace} > 10
+    change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{phase:failed} by {cluster_name,kube_namespace} > 10
   message: |
-    More than ten pods are failing in ({{kubernetes_cluster.name}} cluster)
+    ({{cluster_name.name}}) More than ten pods are failing on {{kube_namespace.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -135,11 +135,11 @@ k8s-unavailable-replica:
   query: |
     max(last_10m):max:kubernetes_state.deployment.replicas_unavailable{*} by {cluster_name} > 0
   message: |
-    ({{event.tags.cluster_name}}) Detected unavailable replicas for longer than 10 minutes
+    ({{cluster_name.name}}) Detected unavailable replicas for longer than 10 minutes
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
+  notify_audit: true
   require_full_window: false
   enable_logs_sample: false
   force_delete: true
@@ -165,11 +165,11 @@ k8s-node-status-unschedulable:
   query: |
     sum(last_5m):sum:kubernetes_state.node.status{status:unschedulable} by {status} > 0
   message: |
-    ({{event.tags.cluster_name}}) Number of unscheduleable nodes is greater than 0
+    Number of unscheduleable nodes is greater than 0
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
+  notify_audit: true
   require_full_window: false
   enable_logs_sample: false
   force_delete: true
@@ -199,7 +199,7 @@ k8s-imagepullbackoff:
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
+  notify_audit: true
   require_full_window: false
   enable_logs_sample: false
   force_delete: true
@@ -225,12 +225,12 @@ k8s-high-cpu-usage:
   query: |
     avg(last_10m):avg:system.cpu.system{*} by {host} > 90
   message: |
-    ({{cluster_name}}) High CPU usage for the last 10 minutes on {host}
+    ({{host.cluster_name}}) High CPU usage for the last 10 minutes on {{host.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -255,12 +255,12 @@ k8s-high-disk-usage:
   query: |
     min(last_5m):min:system.disk.used{*} by {host,cluster_name} / avg:system.disk.total{*} by {host,cluster_name} * 100 > 90
   message: |
-    ({{cluster_name}} High disk usage detected on {{host}}
+    ({{cluster_name.name}} High disk usage detected on {{host.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -286,16 +286,16 @@ k8s-high-memory-usage:
     avg(last_10m):avg:kubernetes.memory.usage_pct{*} by {cluster_name} > 90
   message: |
     {{#is_warning}}
-    {{cluster_name}} memory usage greater than 80% for 10 minutes
+    {{cluster_name.name}} memory usage greater than 80% for 10 minutes
     {{/is_warning}}
     {{#is_alert}}
-    {{cluster_name}} memory usage greater than 90% for 10 minutes
+    {{cluster_name.name}} memory usage greater than 90% for 10 minutes
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -321,16 +321,16 @@ k8s-high-filesystem-usage:
     avg(last_10m):avg:kubernetes.filesystem.usage_pct{*} by {cluster_name} > 90
   message: |
     {{#is_warning}}
-    {{cluster_name}} filesystem usage greater than 80% for 10 minutes
+    {{cluster_name.name}} filesystem usage greater than 80% for 10 minutes
     {{/is_warning}}
     {{#is_alert}}
-    {{cluster_name}} filesystem usage greater than 90% for 10 minutes
+    {{cluster_name.name}} filesystem usage greater than 90% for 10 minutes
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -356,16 +356,16 @@ k8s-network-tx-errors:
     avg(last_10m):avg:kubernetes.network.tx_errors{*} by {cluster_name} > 100
   message: |
     {{#is_warning}}
-    {{cluster_name}} network TX (send) errors occurring 10 times per second
+    {{cluster_name.name}} network TX (send) errors occurring 10 times per second
     {{/is_warning}}
     {{#is_alert}}
-    {{cluster_name}} network TX (send) errors occurring 100 times per second
+    {{cluster_name.name}} network TX (send) errors occurring 100 times per second
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -391,16 +391,16 @@ k8s-network-rx-errors:
     avg(last_10m):avg:kubernetes.network.rx_errors{*} by {cluster_name} > 100
   message: |
     {{#is_warning}}
-    {{cluster_name}} network RX (receive) errors occurring 10 times per second
+    {{cluster_name.name}} network RX (receive) errors occurring 10 times per second
     {{/is_warning}}
     {{#is_alert}}
-    {{cluster_name}} network RX (receive) errors occurring 100 times per second
+    {{cluster_name.name}} network RX (receive) errors occurring 100 times per second
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
-  require_full_window: false
+  notify_audit: true
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true
@@ -425,11 +425,11 @@ k8s-node-not-ready:
   query: |
     "kubernetes_state.node.ready".by('host').last(5).count_by_status()
   message: |
-    ({{host}} {{region}}) Node is reporting 'Not Ready' status
+    ({{host.name}} {{host.region}}) Node is reporting 'Not Ready' status
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
-  notify_audit: false
+  notify_audit: true
   require_full_window: false
   enable_logs_sample: false
   force_delete: true
@@ -444,71 +444,6 @@ k8s-node-not-ready:
   thresholds:
     critical: 3
     #warning:
-    #unknown:
-    #ok:
-    #critical_recovery:
-    #warning_recovery:
-
-ec2-failed-status-check:
-  name: "(EC2) Failed Status Check"
-  type: metric alert
-  query: |
-    avg(last_10m):avg:aws.ec2.status_check_failed{*} by {instance_id} > 0
-  message: |
-    ({stage} {region}) {instance_id} failed a status check
-  escalation_message: ""
-  tags: [ "ManagedBy:Terraform" ]
-  notify_no_data: false
-  notify_audit: false
-  require_full_window: false
-  enable_logs_sample: false
-  force_delete: true
-  include_tags: true
-  locked: false
-  renotify_interval: 60
-  timeout_h: 60
-  evaluation_delay: 60
-  new_host_delay: 300
-  no_data_timeframe: 10
-  threshold_windows: { }
-  thresholds:
-    critical: 0
-    #warning:
-    #unknown:
-    #ok:
-    #critical_recovery:
-    #warning_recovery:
-
-aurora-replica-lag:
-  name: "(RDS) Aurora Replica Lag Detected"
-  type: metric alert
-  query: |
-    min(last_15m):min:aws.rds.aurora_replica_lag{*} by {dbinstanceidentifier} > 1000
-  message: |
-    {{#is_warning}}
-    ({dbinstanceidentifier}) Replica lag has been greater than half a second for more than 15 minutes
-    {{/is_warning}}
-    {{#is_alert}}
-    ({dbinstanceidentifier}) Replica lag has been greater than 1s for more than 15 minutes
-    {{/is_alert}}
-  escalation_message: ""
-  tags: [ "ManagedBy:Terraform" ]
-  notify_no_data: false
-  notify_audit: false
-  require_full_window: false
-  enable_logs_sample: false
-  force_delete: true
-  include_tags: true
-  locked: false
-  renotify_interval: 60
-  timeout_h: 60
-  evaluation_delay: 60
-  new_host_delay: 300
-  no_data_timeframe: 10
-  threshold_windows: { }
-  thresholds:
-    critical: 1000
-    warning: 500
     #unknown:
     #ok:
     #critical_recovery:


### PR DESCRIPTION
## what
* Update datadog monitors
* In the example. refactor the monitors into separate YAML files per category

## why
* When monitor `type` = `query alert`, Datadog does not look into the event tags, so we can't use `event.tags.cluster_name` to detect the cluster and environment
* We need to aggregate the queries by all the parameters we want to use as variables in the alert messages

