### PR TITLE
Add standard rds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,8 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/*.tf       @cloudposse/engineering @cloudposse/approvers
-README.yaml   @cloudposse/engineering @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -46,7 +46,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/---\s+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: auto-release
 on:
   push:
     branches:
+      - main
       - master
+      - production
 
 jobs:
   publish:
@@ -14,7 +16,7 @@ jobs:
         id: get-merged-pull-request
         with:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 name: Validate Codeowners
 on:
+  workflow_dispatch:
+
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-datadog-monitor [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-datadog-monitor.svg)](https://github.com/cloudposse/terraform-datadog-monitor/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -29,7 +30,6 @@
 
 Terraform module to configure [Datadog monitors](https://docs.datadoghq.com/api/v1/monitors/).
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -59,7 +59,6 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
-
 ## Introduction
 
 Datadog monitors are defined in YAML configuration files.
@@ -72,6 +71,7 @@ For more details, refer to:
 
 - [Terraform Datadog monitor resource](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor)
 - [Create a monitor](https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor)
+
 
 ## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
 

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -2,7 +2,7 @@
 # https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
 
 rds-cpuutilization:
-  name: "CPU Utilization above 90%"
+  name: "(RDS) CPU Utilization above 90%"
   type: metric alert
   query: |
     avg(last_15m):avg:aws.rds.cpuutilization{*} by {dbinstanceidentifier} > 90
@@ -37,7 +37,7 @@ rds-cpuutilization:
     #warning_recovery:
 
 rds-disk-queue-depth:
-  name: "Disk queue depth above 64"
+  name: "(RDS) Disk queue depth above 64"
   type: metric alert
   query: |
     avg(last_15m):avg:aws.rds.disk_queue_depth{*} by {dbinstanceidentifier} > 64
@@ -72,7 +72,7 @@ rds-disk-queue-depth:
     #warning_recovery:
 
 rds-freeable-memory:
-  name: "Freeable memory below 256 MB"
+  name: "(RDS) Freeable memory below 256 MB"
   type: metric alert
   query: |
     avg(last_5m):avg:aws.rds.freeable_memory{*} < 256000000
@@ -107,7 +107,7 @@ rds-freeable-memory:
     #warning_recovery:
 
 rds-swap-usage:
-  name: "Swap usage above 256 MB"
+  name: "(RDS) Swap usage above 256 MB"
   type: metric alert
   query: |
     avg(last_15m):avg:aws.rds.swap_usage{*} by {dbinstanceidentifier} > 256000000
@@ -142,7 +142,7 @@ rds-swap-usage:
     #warning_recovery:
 
 rds-database-connections:
-  name: "Anomaly of a large variance in RDS connection count"
+  name: "(RDS) Anomaly of a large variance in RDS connection count"
   type: metric alert
   query: |
     avg(last_4h):anomalies(avg:aws.rds.database_connections{*}, 'basic', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true') >= 1

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -17,7 +17,7 @@ rds-cpuutilization:
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -52,7 +52,7 @@ rds-disk-queue-depth:
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -168,8 +168,8 @@ rds-database-connections:
   new_host_delay: 300
   no_data_timeframe: 10
   threshold_windows:
-  	trigger_window: "last_15m",
-		recovery_window: "last_15m"
+  	trigger_window: "last_15m"
+    recovery_window: "last_15m"
   #thresholds:
     #critical: 
     #warning: 

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -1,0 +1,179 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+rds-cpuutilization:
+  name: "CPU Utilization above 90%"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.rds.cpuutilization{*} by {dbinstanceidentifier} > 90
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) CPU Utilization above 85%
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) CPU Utilization above 90%
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 90
+    warning: 85
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:
+
+rds-disk-queue-depth:
+  name: "Disk queue depth above 64"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.rds.disk_queue_depth{*} by {dbinstanceidentifier} > 64
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) Disk queue depth above 44
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) Disk queue depth above 64
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 64
+    warning: 44
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:
+
+rds-freeable-memory:
+  name: "Freeable memory below 256 MB"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.rds.freeable_memory{*} by {dbinstanceidentifier} < 256
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) Freeable memory below 512 MB
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) Freeable memory below 256 MB
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 256
+    warning: 512
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:
+
+rds-swap-usage:
+  name: "Swap usage above 256 MB"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.rds.swap_usage{*} by {dbinstanceidentifier} > 256
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) Swap usage above 128 MB
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) Swap usage above 256 MB
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 256000000
+    warning: 128000000
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:
+
+rds-database-connections:
+  name: "Anomalous connection count"
+  type: metric alert
+  query: |
+    avg(last_4h):anomalies(avg:aws.rds.database_connections{*}, 'basic', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) Anomalous connection count
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) Anomalous connection count
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows:
+  	trigger_window: "last_15m",
+		recovery_window: "last_15m"
+  #thresholds:
+    #critical: 
+    #warning: 
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -75,7 +75,7 @@ rds-freeable-memory:
   name: "Freeable memory below 256 MB"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.rds.freeable_memory{*} by {dbinstanceidentifier} < 256
+    avg(last_5m):avg:aws.rds.freeable_memory{*} < 256000000
   message: |
     {{#is_warning}}
     ({dbinstanceidentifier}) Freeable memory below 512 MB
@@ -99,8 +99,8 @@ rds-freeable-memory:
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
-    critical: 256
-    warning: 512
+    critical: 256000000
+    warning: 512000000
     #unknown:
     #ok:
     #critical_recovery:
@@ -110,7 +110,7 @@ rds-swap-usage:
   name: "Swap usage above 256 MB"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.rds.swap_usage{*} by {dbinstanceidentifier} > 256
+    avg(last_15m):avg:aws.rds.swap_usage{*} by {dbinstanceidentifier} > 256000000
   message: |
     {{#is_warning}}
     ({dbinstanceidentifier}) Swap usage above 128 MB

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -43,7 +43,7 @@ rds-disk-queue-depth:
     avg(last_15m):avg:aws.rds.disk_queue_depth{*} by {dbinstanceidentifier} > 64
   message: |
     {{#is_warning}}
-    ({dbinstanceidentifier}) Disk queue depth above 44
+    ({dbinstanceidentifier}) Disk queue depth above 48
     {{/is_warning}}
     {{#is_alert}}
     ({dbinstanceidentifier}) Disk queue depth above 64
@@ -65,7 +65,7 @@ rds-disk-queue-depth:
   threshold_windows: { }
   thresholds:
     critical: 64
-    warning: 44
+    warning: 48
     #unknown:
     #ok:
     #critical_recovery:

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -168,7 +168,7 @@ rds-database-connections:
   new_host_delay: 300
   no_data_timeframe: 10
   threshold_windows:
-  	trigger_window: "last_15m"
+    trigger_window: "last_15m"
     recovery_window: "last_15m"
   #thresholds:
     #critical: 

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -157,7 +157,7 @@ rds-database-connections:
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -142,16 +142,16 @@ rds-swap-usage:
     #warning_recovery:
 
 rds-database-connections:
-  name: "Anomalous connection count"
+  name: "Anomaly of a large variance in RDS connection count"
   type: metric alert
   query: |
-    avg(last_4h):anomalies(avg:aws.rds.database_connections{*}, 'basic', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
+    avg(last_4h):anomalies(avg:aws.rds.database_connections{*}, 'basic', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
   message: |
     {{#is_warning}}
-    ({dbinstanceidentifier}) Anomalous connection count
+    ({dbinstanceidentifier}) Anomaly of a large variance in RDS connection count
     {{/is_warning}}
     {{#is_alert}}
-    ({dbinstanceidentifier}) Anomalous connection count
+    ({dbinstanceidentifier}) Anomaly of a large variance in RDS connection count
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
@@ -170,10 +170,10 @@ rds-database-connections:
   threshold_windows:
     trigger_window: "last_15m"
     recovery_window: "last_15m"
-  #thresholds:
-    #critical: 
+  thresholds:
+    critical: 1
     #warning: 
     #unknown:
     #ok:
-    #critical_recovery:
+    critical_recovery: 0
     #warning_recovery:

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -122,7 +122,7 @@ rds-swap-usage:
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -87,7 +87,7 @@ rds-freeable-memory:
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: true
-  require_full_window: false
+  require_full_window: true
   enable_logs_sample: false
   force_delete: true
   include_tags: true


### PR DESCRIPTION
## what
* Adding baseline RDS Datadog standard monitors for **cpuutilization, database-connections, disk-queue-depth, freeable-memory, swap-usage**

## why
* Establish an out of box baseline set of monitors that can be used with Datadog standard integration

