### PR TITLE
Add dd amazon mq

### DIFF
--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -5,13 +5,13 @@ amq-cpu-utilization:
   name: "(AMQ) CPU Utilization above 90%"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.amazonmq.cpu_utilization{*} by {dbinstanceidentifier} > 90
+    avg(last_15m):avg:aws.amazonmq.cpu_utilization{*} by {broker} > 90
   message: |
     {{#is_warning}}
-    ({dbinstanceidentifier}) CPU Utilization above 85%
+    ({broker}) CPU Utilization above 85%
     {{/is_warning}}
     {{#is_alert}}
-    ({dbinstanceidentifier}) CPU Utilization above 90%
+    ({broker}) CPU Utilization above 90%
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -40,7 +40,7 @@ amq-heap-usage:
   name: "(AMQ) JVM heap usage above 95%"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.amazonmq.heap_usage{*} by {broker} > 90
+    avg(last_15m):avg:aws.amazonmq.heap_usage{*} by {broker} > 95
   message: |
     {{#is_warning}}
     ({broker}) - JVM heap usage above 90%

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -8,17 +8,10 @@ amq-cpu-utilization:
     avg(last_15m):avg:aws.amazonmq.cpu_utilization{*} by {broker} > 90
   message: |
     {{#is_warning}}
-<<<<<<< HEAD
     ({broker}) - CPU Utilization above 85%
     {{/is_warning}}
     {{#is_alert}}
     ({broker}) - CPU Utilization above 90%
-=======
-    ({broker}) CPU Utilization above 85%
-    {{/is_warning}}
-    {{#is_alert}}
-    ({broker}) CPU Utilization above 90%
->>>>>>> 8ad5f4080a7e76fa4956c8a26c18546cffe5693e
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
@@ -43,7 +36,6 @@ amq-cpu-utilization:
     #critical_recovery:
     #warning_recovery:
 
-<<<<<<< HEAD
 amq-heap-usage:
   name: "(AMQ) JVM heap usage above 95%"
   type: metric alert
@@ -55,19 +47,6 @@ amq-heap-usage:
     {{/is_warning}}
     {{#is_alert}}
     ({broker}) - JVM heap usage above 95%
-=======
-amq-network-in:
-  name: "(AMQ) Anomaly of a large variance in network-in bytes"
-  type: metric alert
-  query: |
-    aws.amazonmq.network_in
-  message: |
-    {{#is_warning}}
-    ({broker}) Anomaly of a large variance in network-in bytes
-    {{/is_warning}}
-    {{#is_alert}}
-    ({broker}) Anomaly of a large variance in network-in bytes
->>>>>>> 8ad5f4080a7e76fa4956c8a26c18546cffe5693e
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
@@ -83,7 +62,6 @@ amq-network-in:
   evaluation_delay: 60
   new_host_delay: 300
   no_data_timeframe: 10
-<<<<<<< HEAD
   threshold_windows: { }
   thresholds:
     critical: 95
@@ -116,8 +94,6 @@ amq-network-in:
   evaluation_delay: 900
   new_host_delay: 300
   no_data_timeframe: 10
-=======
->>>>>>> 8ad5f4080a7e76fa4956c8a26c18546cffe5693e
   threshold_windows:
     trigger_window: "last_15m"
     recovery_window: "last_15m"
@@ -133,7 +109,6 @@ amq-network-out:
   name: "(AMQ) Anomaly of a large variance in network-out bytes"
   type: metric alert
   query: |
-<<<<<<< HEAD
     avg(last_4h):anomalies(avg:aws.amazonmq.network_out{*} by {broker}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
   message: |
     {{#is_alert}}
@@ -199,30 +174,3 @@ amq-current-connections-count:
     #ok:
     #critical_recovery:
     #warning_recovery: 
-=======
-    aws.amazonmq.network_out
-
-amq-current-connections-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.current_connections_count
-
-amq-total-message-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.total_message_count
-
-amq-enqueue-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.enqueue_count
-
-amq-dequeue-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.dequeue_count
->>>>>>> 8ad5f4080a7e76fa4956c8a26c18546cffe5693e

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -1,6 +1,41 @@
 # The official Datadog API documentation with available query parameters & alert types:
 # https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
 
+amq-cpu-utilization:
+  name: "(AMQ) CPU Utilization above 90%"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.amazonmq.cpu_utilization{*} by {dbinstanceidentifier} > 90
+  message: |
+    {{#is_warning}}
+    ({dbinstanceidentifier}) CPU Utilization above 85%
+    {{/is_warning}}
+    {{#is_alert}}
+    ({dbinstanceidentifier}) CPU Utilization above 90%
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 90
+    warning: 85
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:
+
 amq-network-in:
   name: "(AMQ) Anomaly of a large variance in network-in bytes"
   type: metric alert
@@ -43,12 +78,6 @@ amq-network-out:
   type: metric alert
   query: |
     aws.amazonmq.network_out
-
-amq-cpu-utilization:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.cpu_utilization
 
 amq-current-connections-count:
   name: "(AMQ) Anomaly of a large variance in "

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -8,10 +8,10 @@ amq-cpu-utilization:
     avg(last_15m):avg:aws.amazonmq.cpu_utilization{*} by {broker} > 90
   message: |
     {{#is_warning}}
-    ({broker}) CPU Utilization above 85%
+    ({broker}) - CPU Utilization above 85%
     {{/is_warning}}
     {{#is_alert}}
-    ({broker}) CPU Utilization above 90%
+    ({broker}) - CPU Utilization above 90%
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
@@ -36,17 +36,17 @@ amq-cpu-utilization:
     #critical_recovery:
     #warning_recovery:
 
-amq-network-in:
-  name: "(AMQ) Anomaly of a large variance in network-in bytes"
+amq-heap-usage:
+  name: "(AMQ) JVM heap usage above 95%"
   type: metric alert
   query: |
-    aws.amazonmq.network_in
+    avg(last_15m):avg:aws.amazonmq.heap_usage{*} by {broker} > 90
   message: |
     {{#is_warning}}
-    ({broker}) Anomaly of a large variance in network-in bytes
+    ({broker}) - JVM heap usage above 90%
     {{/is_warning}}
     {{#is_alert}}
-    ({broker}) Anomaly of a large variance in network-in bytes
+    ({broker}) - JVM heap usage above 95%
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
@@ -60,6 +60,38 @@ amq-network-in:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 95
+    warning: 90
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:   
+
+amq-network-in:
+  name: "(AMQ) Anomaly of a large variance in network-in bytes"
+  type: metric alert
+  query: |
+    avg(last_4h):anomalies(avg:aws.amazonmq.network_in{*} by {broker}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
+  message: |
+    {{#is_alert}}
+    ({broker}) - Anomaly of a large variance in network-in bytes
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 900
   new_host_delay: 300
   no_data_timeframe: 10
   threshold_windows:
@@ -77,28 +109,68 @@ amq-network-out:
   name: "(AMQ) Anomaly of a large variance in network-out bytes"
   type: metric alert
   query: |
-    aws.amazonmq.network_out
+    avg(last_4h):anomalies(avg:aws.amazonmq.network_out{*} by {broker}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
+  message: |
+    {{#is_alert}}
+    ({broker}) - Anomaly of a large variance in network-out bytes
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 900
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows:
+    trigger_window: "last_15m"
+    recovery_window: "last_15m"
+  thresholds:
+    critical: 1
+    #warning: 
+    #unknown:
+    #ok:
+    critical_recovery: 0
+    #warning_recovery:
 
 amq-current-connections-count:
-  name: "(AMQ) Anomaly of a large variance in "
+  name: "(AMQ) Variance of 100% in broker connections"
   type: metric alert
-  query: |
-    aws.amazonmq.current_connections_count
-
-amq-total-message-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.total_message_count
-
-amq-enqueue-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.enqueue_count
-
-amq-dequeue-count:
-  name: "(AMQ) Anomaly of a large variance in "
-  type: metric alert
-  query: |
-    aws.amazonmq.dequeue_count
+  query: >
+    sum(last_5m):abs( ( ( avg:aws.amazonmq.current_connections_count{*} by {broker}.as_count() - hour_before(avg:aws.amazonmq.current_connections_count{*}
+    by {broker}.as_count()) ) / hour_before(avg:aws.amazonmq.current_connections_count{*} by {broker}.as_count()) ) * 100 ) > 99
+  message: |
+    {{#is_warning}}
+    ({broker}) - Variance of 75% in broker connections
+    {{/is_warning}}
+    {{#is_alert}}
+    ({broker}) - Variance of 100% in broker connections
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 99
+    warning: 74
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery: 

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -1,0 +1,75 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+amq-network-in:
+  name: "(AMQ) Anomaly of a large variance in network-in bytes"
+  type: metric alert
+  query: |
+    aws.amazonmq.network_in
+  message: |
+    {{#is_warning}}
+    ({broker}) Anomaly of a large variance in network-in bytes
+    {{/is_warning}}
+    {{#is_alert}}
+    ({broker}) Anomaly of a large variance in network-in bytes
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows:
+    trigger_window: "last_15m"
+    recovery_window: "last_15m"
+  thresholds:
+    critical: 1
+    #warning: 
+    #unknown:
+    #ok:
+    critical_recovery: 0
+    #warning_recovery:
+
+amq-network-out:
+  name: "(AMQ) Anomaly of a large variance in network-out bytes"
+  type: metric alert
+  query: |
+    aws.amazonmq.network_out
+
+amq-cpu-utilization:
+  name: "(AMQ) Anomaly of a large variance in "
+  type: metric alert
+  query: |
+    aws.amazonmq.cpu_utilization
+
+amq-current-connections-count:
+  name: "(AMQ) Anomaly of a large variance in "
+  type: metric alert
+  query: |
+    aws.amazonmq.current_connections_count
+
+amq-total-message-count:
+  name: "(AMQ) Anomaly of a large variance in "
+  type: metric alert
+  query: |
+    aws.amazonmq.total_message_count
+
+amq-enqueue-count:
+  name: "(AMQ) Anomaly of a large variance in "
+  type: metric alert
+  query: |
+    aws.amazonmq.enqueue_count
+
+amq-dequeue-count:
+  name: "(AMQ) Anomaly of a large variance in "
+  type: metric alert
+  query: |
+    aws.amazonmq.dequeue_count

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -140,17 +140,13 @@ amq-network-out:
     #warning_recovery:
 
 amq-current-connections-count:
-  name: "(AMQ) Variance of 100% in broker connections"
+  name: "(AMQ) Anomaly of a large variance in broker connections"
   type: metric alert
-  query: >
-    sum(last_5m):abs( ( ( avg:aws.amazonmq.current_connections_count{*} by {broker}.as_count() - hour_before(avg:aws.amazonmq.current_connections_count{*}
-    by {broker}.as_count()) ) / hour_before(avg:aws.amazonmq.current_connections_count{*} by {broker}.as_count()) ) * 100 ) > 99
+  query: |
+    avg(last_4h):anomalies(avg:aws.amazonmq.current_connections_count{*}.as_count(), 'basic', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
   message: |
-    {{#is_warning}}
-    ({broker}) - Variance of 75% in broker connections
-    {{/is_warning}}
     {{#is_alert}}
-    ({broker}) - Variance of 100% in broker connections
+    ({broker}) - Anomaly of a large variance in broker connections
     {{/is_alert}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
@@ -163,14 +159,16 @@ amq-current-connections-count:
   locked: false
   renotify_interval: 60
   timeout_h: 60
-  evaluation_delay: 60
+  evaluation_delay: 900
   new_host_delay: 300
   no_data_timeframe: 10
-  threshold_windows: { }
+  threshold_windows:
+    trigger_window: "last_15m"
+    recovery_window: "last_15m"
   thresholds:
-    critical: 99
-    warning: 74
+    critical: 1
+    #warning: 
     #unknown:
     #ok:
-    #critical_recovery:
-    #warning_recovery: 
+    critical_recovery: 0
+    #warning_recovery:


### PR DESCRIPTION
## what
* Adding baseline Amazon MQ Datadog standard monitors 

## why
* Establish an out of box baseline set of monitors that can be used with Datadog Amazon MQ integration 