### PR TITLE
 Fix/feat: Improve Kubernetes Alert Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] |
-|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
+|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -373,6 +373,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [SweetOps_homepage]: https://github.com/SweetOps
   [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -105,3 +105,5 @@ contributors:
     github: "aknysh"
   - name: "Vladimir"
     github: "SweetOps"
+  - name: "Yonatan Koren"
+    github: "korenyoni"

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -1,0 +1,174 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+amq-cpu-utilization:
+  name: "(AMQ) CPU Utilization above 90%"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.amazonmq.cpu_utilization{*} by {broker} > 90
+  message: |
+    {{#is_warning}}
+    ({broker}) - CPU Utilization above 85%
+    {{/is_warning}}
+    {{#is_alert}}
+    ({broker}) - CPU Utilization above 90%
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 90
+    warning: 85
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:
+
+amq-heap-usage:
+  name: "(AMQ) JVM heap usage above 95%"
+  type: metric alert
+  query: |
+    avg(last_15m):avg:aws.amazonmq.heap_usage{*} by {broker} > 95
+  message: |
+    {{#is_warning}}
+    ({broker}) - JVM heap usage above 90%
+    {{/is_warning}}
+    {{#is_alert}}
+    ({broker}) - JVM heap usage above 95%
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 95
+    warning: 90
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:   
+
+amq-network-in:
+  name: "(AMQ) Anomaly of a large variance in network-in bytes"
+  type: metric alert
+  query: |
+    avg(last_4h):anomalies(avg:aws.amazonmq.network_in{*} by {broker}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
+  message: |
+    {{#is_alert}}
+    ({broker}) - Anomaly of a large variance in network-in bytes
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 900
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows:
+    trigger_window: "last_15m"
+    recovery_window: "last_15m"
+  thresholds:
+    critical: 1
+    #warning: 
+    #unknown:
+    #ok:
+    critical_recovery: 0
+    #warning_recovery:
+
+amq-network-out:
+  name: "(AMQ) Anomaly of a large variance in network-out bytes"
+  type: metric alert
+  query: |
+    avg(last_4h):anomalies(avg:aws.amazonmq.network_out{*} by {broker}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
+  message: |
+    {{#is_alert}}
+    ({broker}) - Anomaly of a large variance in network-out bytes
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 900
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows:
+    trigger_window: "last_15m"
+    recovery_window: "last_15m"
+  thresholds:
+    critical: 1
+    #warning: 
+    #unknown:
+    #ok:
+    critical_recovery: 0
+    #warning_recovery:
+
+amq-current-connections-count:
+  name: "(AMQ) Anomaly of a large variance in broker connections"
+  type: metric alert
+  query: |
+    avg(last_4h):anomalies(avg:aws.amazonmq.current_connections_count{*}.as_count(), 'basic', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
+  message: |
+    {{#is_alert}}
+    ({broker}) - Anomaly of a large variance in broker connections
+    {{/is_alert}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 60
+  evaluation_delay: 900
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows:
+    trigger_window: "last_15m"
+    recovery_window: "last_15m"
+  thresholds:
+    critical: 1
+    #warning: 
+    #unknown:
+    #ok:
+    critical_recovery: 0
+    #warning_recovery:

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -56,9 +56,9 @@ k8s-statefulset-replica-down:
   name: "(k8s) StatefulSet Replica Pod is down"
   type: query alert
   query: |
-    max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {cluster_name,statefulset} - sum:kubernetes_state.statefulset.replicas_ready{*} by {cluster_name,statefulset} >= 2
+    max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {cluster_name,kube_namespace,statefulset} - sum:kubernetes_state.statefulset.replicas_ready{*} by {cluster_name,kube_namespace,statefulset} >= 2
   message: |
-    ({{cluster_name.name}} {{statefulset.name}}) More than one StatefulSet Replica's pods are down
+    ({{cluster_name.name}} {{statefulset.name}}) More than one StatefulSet Replica's pods are down on {{kube_namespace.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
@@ -82,7 +82,7 @@ k8s-crashloopBackOff:
   name: "(k8s) CrashloopBackOff detected"
   type: query alert
   query: |
-    max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:crashloopbackoff} by {kube_namespace,pod_name} >= 1
+    max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:crashloopbackoff} by {cluster_name,kube_namespace,pod_name} >= 1
   message: |
     ({{cluster_name.name}}) pod {{pod_name.name}} is CrashloopBackOff on {{kube_namespace.name}}
   escalation_message: ""
@@ -101,7 +101,7 @@ k8s-crashloopBackOff:
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
-    critical: 1    
+    critical: 1
 
 k8s-multiple-pods-failing:
   name: "(k8s) Multiple Pods are failing"
@@ -133,9 +133,9 @@ k8s-unavailable-deployment-replica:
   name: "(k8s) Unavailable Deployment Replica(s) detected"
   type: metric alert
   query: |
-    max(last_10m):max:kubernetes_state.deployment.replicas_unavailable{*} by {cluster_name} > 0
+    max(last_10m):max:kubernetes_state.deployment.replicas_unavailable{*} by {cluster_name,kube_namespace} > 0
   message: |
-    ({{cluster_name.name}}) Detected unavailable Deployment replicas for longer than 10 minutes
+    ({{cluster_name.name}}) Detected unavailable Deployment replicas for longer than 10 minutes on {{kube_namespace.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
@@ -163,9 +163,9 @@ k8s-unavailable-statefulset-replica:
   name: "(k8s) Unavailable Statefulset Replica(s) detected"
   type: metric alert
   query: |
-    max(last_10m):max:kubernetes_state.statefulset.replicas_unavailable{*} by {cluster_name} > 0
+    max(last_10m):max:kubernetes_state.statefulset.replicas_unavailable{*} by {cluster_name,kube_namespace} > 0
   message: |
-    ({{cluster_name.name}}) Detected unavailable Statefulset replicas for longer than 10 minutes
+    ({{cluster_name.name}}) Detected unavailable Statefulset replicas for longer than 10 minutes on {{kube_namespace.name}}
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
@@ -447,7 +447,7 @@ k8s-network-rx-errors:
     #unknown:
     #ok:
     #critical_recovery:
-    #warning_recovery:    
+    #warning_recovery:
 
 k8s-node-not-ready:
   name: "(k8s) Node Not Ready"
@@ -455,7 +455,7 @@ k8s-node-not-ready:
   query: |
     "kubernetes_state.node.ready".by('host').last(5).count_by_status()
   message: |
-    ({{host.name}} {{host.region}}) Node is reporting 'Not Ready' status
+    ({{host.cluster_name}} {{host.name}} {{host.region}}) Node is reporting 'Not Ready' status
   escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
@@ -512,10 +512,11 @@ k8s-kube-api-down:
 k8s-increased-pod-crash:
   name: "(k8s) Increased Pod Crashes"
   type: query alert
-  query: "avg(last_5m):avg:kubernetes_state.container.restarts{*} by {pod} - hour_before(avg:kubernetes_state.container.restarts{*} by {pod}) > 3"
+  query: |
+    avg(last_5m):avg:kubernetes_state.container.restarts{*} by {cluster_name,kube_namespace,pod} - hour_before(avg:kubernetes_state.container.restarts{*} by {cluster_name,kube_namespace,pod}) > 3
   message: |-
-    ({{pod.name}}) has crashed repeatedly over the last hour
-  escalation_message: ""  
+    ({{cluster_name.name}} {{kube_namespace.name}} {{pod.name}}) has crashed repeatedly over the last hour
+  escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: false
@@ -541,10 +542,11 @@ k8s-increased-pod-crash:
 k8s-hpa-errors:
   name: "(k8s) HPA Errors"
   type: event alert
-  query: "events('sources:kubernetes priority:all \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200"
+  query: |
+    events('sources:kubernetes priority:all \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200
   message: |-
-    A high number of hpa failures (> ({{threshold}}) are occurring.
-  escalation_message: ""  
+    ({{event.tags.cluster_name}}) A high number of hpa failures (> ({{threshold}}) are occurring.
+  escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: false
@@ -570,11 +572,12 @@ k8s-hpa-errors:
 k8s-pending-pods:
   name: "(k8s) Pending Pods"
   type: metric alert
-  query: "min(last_30m):sum:kubernetes_state.pod.status_phase{phase:running} - sum:kubernetes_state.pod.status_phase{phase:running} + sum:kubernetes_state.pod.status_phase{phase:pending}.fill(zero) >= 1"
+  query: |
+    min(last_30m):sum:kubernetes_state.pod.status_phase{phase:running} by {cluster_name} - sum:kubernetes_state.pod.status_phase{phase:running} by {cluster_name} + sum:kubernetes_state.pod.status_phase{phase:pending} by {cluster_name}.fill(zero) >= 1
   message: |-
-    There has been at least 1 pod Pending for 30 minutes.
+    ({{cluster_name.name}}) There has been at least 1 pod Pending for 30 minutes.
     There are currently ({{value}}) pods Pending.
-  escalation_message: ""  
+  escalation_message: ""
   tags: [ "ManagedBy:Terraform" ]
   notify_no_data: false
   notify_audit: false
@@ -596,3 +599,4 @@ k8s-pending-pods:
     #ok:
     #critical_recovery:
     #warning_recovery:
+


### PR DESCRIPTION
## what
* Improve Kubernetes alert context by aggregating on `cluster_name` or `cluster_name,kube_namespace` where possible
* Add variables made available by these contexts to the alert message, such that alerted platforms can make use of additional data (e.g. OpsGenie)

## why
* Kubernetes alerts with more information i.e. which cluster, namespace are more actionable

## references
* N/A

