### PR TITLE
Fix: Upgrade to Datadog Terraform Provider 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ For automated tests of the complete example using [bats](https://github.com/bats
 (which tests and deploys the example on Datadog), see [test](test).
 
 ```hcl
-  module "yaml_config" {
-    source = "git::https://github.com/cloudposse/terraform-yaml-config.git?ref=master"
+  module "monitor_yaml_config" {
+    source  = "cloudposse/config/yaml"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
 
     map_config_local_base_path = path.module
     map_config_paths           = ["catalog/*.yaml"]
@@ -121,10 +123,24 @@ For automated tests of the complete example using [bats](https://github.com/bats
     context = module.this.context
   }
 
-  module "datadog_monitors" {
-    source = "git::https://github.com/cloudposse/terraform-datadog-monitor.git?ref=master"
+  module "synthetics_yaml_config" {
+    source  = "cloudposse/config/yaml"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
 
-    datadog_monitors     = module.yaml_config.map_configs
+    map_config_local_base_path = path.module
+    map_config_paths           = ["catalog/synthetics/*.yaml"]
+
+    context = module.this.context
+  }
+
+  module "datadog_monitors" {
+    source  = "cloudposse/monitor/datadog"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
+
+    datadog_monitors     = module.monitor_yaml_config.map_configs
+    datadog_synthetics   = module.synthetics_yaml_config.map_configs
     alert_tags           = ["@opsgenie"]
     alert_tags_separator = "\n"
 

--- a/README.yaml
+++ b/README.yaml
@@ -70,8 +70,10 @@ usage: |-
   (which tests and deploys the example on Datadog), see [test](test).
 
   ```hcl
-    module "yaml_config" {
-      source = "git::https://github.com/cloudposse/terraform-yaml-config.git?ref=master"
+    module "monitor_yaml_config" {
+      source  = "cloudposse/config/yaml"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
 
       map_config_local_base_path = path.module
       map_config_paths           = ["catalog/*.yaml"]
@@ -79,10 +81,24 @@ usage: |-
       context = module.this.context
     }
 
-    module "datadog_monitors" {
-      source = "git::https://github.com/cloudposse/terraform-datadog-monitor.git?ref=master"
+    module "synthetics_yaml_config" {
+      source  = "cloudposse/config/yaml"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
 
-      datadog_monitors     = module.yaml_config.map_configs
+      map_config_local_base_path = path.module
+      map_config_paths           = ["catalog/synthetics/*.yaml"]
+
+      context = module.this.context
+    }
+
+    module "datadog_monitors" {
+      source  = "cloudposse/monitor/datadog"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
+
+      datadog_monitors     = module.monitor_yaml_config.map_configs
+      datadog_synthetics   = module.synthetics_yaml_config.map_configs
       alert_tags           = ["@opsgenie"]
       alert_tags_separator = "\n"
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 2.13"
+      version = ">= 3.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -23,14 +23,21 @@ resource "datadog_monitor" "default" {
   enable_logs_sample  = lookup(each.value, "enable_logs_sample", null)
   locked              = lookup(each.value, "locked", null)
   force_delete        = lookup(each.value, "force_delete", null)
-  threshold_windows   = lookup(each.value, "threshold_windows", null)
-  thresholds          = lookup(each.value, "thresholds", null)
+
+  monitor_thresholds {
+    warning           = lookup(each.value.thresholds, "warning", null)
+    warning_recovery  = lookup(each.value.thresholds, "warning_recovery", null)
+    critical          = lookup(each.value.thresholds, "critical", null)
+    critical_recovery = lookup(each.value.thresholds, "critical_recovery", null)
+    ok                = lookup(each.value.thresholds, "ok", null)
+    unknown           = lookup(each.value.thresholds, "unknown", null)
+  }
+  monitor_threshold_windows {
+    recovery_window = lookup(each.value.threshold_windows, "recovery_window", null)
+    trigger_window  = lookup(each.value.threshold_windows, "trigger_window", null)
+  }
 
   tags = lookup(each.value, "tags", null)
-
-  lifecycle {
-    ignore_changes = [silenced]
-  }
 }
 
 resource "datadog_synthetics_test" "default" {
@@ -44,7 +51,7 @@ resource "datadog_synthetics_test" "default" {
   locations = each.value.locations
   tags      = lookup(each.value, "tags", null)
 
-  request = {
+  request_definition {
     host       = lookup(each.value.request, "host", null)
     port       = lookup(each.value.request, "port", null)
     url        = lookup(each.value.request, "url", null)


### PR DESCRIPTION
## what
* Remove deprecated Datadog Provider resources and upgrade to Datadog Terraform Provider 3.0.0
* Update README to reflect use Terraform registry as a module source, `datadog_synthetics` variable

## why
* Datadog Terraform Provider 3.0.0 deprecated certain resources rendering this module unusable.

## references
* Co-authored with changes from #30 

