### PR TITLE
Feat: Add k8s Monitor for DaemonSets to Catalog

### DIFF
--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -78,6 +78,32 @@ k8s-statefulset-replica-down:
     warning: 1
     critical: 2
 
+
+k8s-daemonset-pod-down:
+  name: "(k8s) DaemonSet Pod is down"
+  type: query alert
+  query: |
+    max(last_15m):sum:kubernetes_state.daemonset.desired{*} by {cluster_name,kube_namespace,daemonset} - sum:kubernetes_state.daemonset.ready{*} by {cluster_name,kube_namespace,daemonset} >= 1
+  message: |
+    ({{cluster_name.name}} {{daemonset.name}}) One or more DaemonSet pods are down on {{kube_namespace.name}}
+  escalation_message: ""
+  tags: [ "ManagedBy:Terraform" ]
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: false
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 0
+  timeout_h: 0
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 1
+
 k8s-crashloopBackOff:
   name: "(k8s) CrashloopBackOff detected"
   type: query alert


### PR DESCRIPTION
## what
* Add `k8s-daemonset-pod-down` monitor in k8s catalog

## why
* A monitor for DaemonSet pods being down is necessary. Usually, DaemonSets are for low-level system components, and a DaemonSet being down should definitely be visible.

## references
* N./A

